### PR TITLE
Dont analyze any files when cc config include_paths is empty list

### DIFF
--- a/codeclimate-radon
+++ b/codeclimate-radon
@@ -13,10 +13,10 @@ if os.path.exists("/config.json"):
     if config.get("config") and config["config"].get("threshold"):
         threshold = config["config"]["threshold"].lower()
 
-    if config.get("include_paths"):
-        config_paths = config.get("include_paths")
+    i_paths = config.get("include_paths")
+    if type(i_paths) == list:
         python_paths = []
-        for i in config_paths:
+        for i in i_paths:
             ext = os.path.splitext(i)[1]
             if os.path.isdir(i) or "py" in ext:
                 python_paths.append(i)


### PR DESCRIPTION
When a user runs `codeclimate analyze <path>`, workspace paths to analyze get passed
into `config.json` as a list.

The previous implementation made the mistake of expecting an empty list to be truthy,
and consequently thought the `include_paths` key was missing if include_paths == [].

As a result, it analyzed all files in directory instead of none.

This change fixes that behavior by checking the type of object that's returned
by config.get("include_paths").

cc @codeclimate/review @mrb
